### PR TITLE
Fix: should display the image even if the fade attribute is not settled

### DIFF
--- a/lazy-image.html
+++ b/lazy-image.html
@@ -107,6 +107,9 @@
             imgEl.style.display = 'block';
           }
         }
+        else {
+          imgEl.style.display = 'block';
+        }
       }
 
       disconnectedCallback() {


### PR DESCRIPTION
You can see the bug in the demo page, the last lazy-image should be displayed but isn't https://www.webcomponents.org/element/DinethH/lazy-image/demo/demo/index.html