### PR TITLE
Fix: updating the `src` property didn't update the image `src` attribute

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = false

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
+    "iron-list": "PolymerElements/iron-list#^2.0.11"
   },
   "resolutions": {
     "polymer": "^2.0.0"

--- a/demo/index.html
+++ b/demo/index.html
@@ -11,6 +11,7 @@
 
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../iron-list/iron-list.html" />
   <link rel="import" href="../lazy-image.html">
 
   <custom-style>
@@ -22,7 +23,7 @@
 
 <body>
   <div class="vertical-section-container centered">
-    <h3>Basic lazy-image demo</h3>
+    <h3>Basic <code>lazy-image</code> demo</h3>
     <demo-snippet>
       <template>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis eligendi neque quae ab similique repudiandae
@@ -75,7 +76,32 @@
           accusamus nemo optio consequuntur laudantium. Rem asperiores aperiam et architecto libero unde nobis sit quasi.</p>
 
         <lazy-image src="b.jpg"></lazy-image>
+      </template>
+    </demo-snippet>
+  </div>
 
+  <div class="vertical-section-container centered">
+    <h3><code>lazy-image</code> in an <code>iron-list</code> demo</h3>
+    <demo-snippet>
+      <template>
+        <iron-list items='["a", "a", "a", "a", "a", "a", "b", "b", "b", "b", "b", "b"]' as="item" style="height: 20em; overflow: auto;">
+          <template>
+            <lazy-image src="[[item]].jpg" style="width: 5em; height: 5em;"></lazy-image>
+          </template>
+        </iron-list>
+      </template>
+    </demo-snippet>
+  </div>
+
+  <div class="vertical-section-container centered">
+    <h3><code>lazy-image</code> with <code>fade</code> property in an <code>iron-list</code> demo</h3>
+    <demo-snippet>
+      <template>
+        <iron-list items='["a", "a", "a", "a", "a", "a", "b", "b", "b", "b", "b", "b"]' as="item" style="height: 20em; overflow: auto;">
+          <template>
+            <lazy-image src="[[item]].jpg" fade style="width: 5em; height: 5em;"></lazy-image>
+          </template>
+        </iron-list>
       </template>
     </demo-snippet>
   </div>

--- a/lazy-image.html
+++ b/lazy-image.html
@@ -67,7 +67,8 @@
            * */
           placeholder: {
             type: String,
-            value: null
+            value: null,
+            observer: '_placeholderChanged',
           },
           /**
            *  If truthy, the image will fade into view.
@@ -99,7 +100,6 @@
       static get observers() {
         return [
           '_displayImageWhenNVisible(src, visible, loaded)',
-          '_placeholderChanged(placeholder)'
         ]
       }
 

--- a/lazy-image.html
+++ b/lazy-image.html
@@ -109,10 +109,6 @@
         }
       }
 
-      disconnectedCallback() {
-        super.disconnectedCallback();
-      }
-
       _placeholderChanged(placeholder) {
         if (placeholder) {
           this.style.backgroundImage = `url(${placeholder})`;

--- a/lazy-image.html
+++ b/lazy-image.html
@@ -3,7 +3,7 @@
 <dom-module id="lazy-image">
   <template>
     <style>
-       :host {
+      :host {
         display: block;
         background-size: 100% 100%;
         position: relative;
@@ -54,7 +54,7 @@
            * */
           alt: String,
           /**
-           *  Base64 encoded data to be used as a placeholder until the image is loaded into view. 
+           *  Base64 encoded data to be used as a placeholder until the image is loaded into view.
            *  Note: A width and a height must be specified when using the placeholder.
            * */
           placeholder: {

--- a/lazy-image.html
+++ b/lazy-image.html
@@ -17,7 +17,11 @@
         will-change: opacity;
       }
 
-      .fade-in {
+      :host([loaded]) img {
+        display: block;
+      }
+
+      :host([fade]) img {
         animation: fade-in 300ms ease-in-out;
       }
 
@@ -27,7 +31,8 @@
         }
       }
     </style>
-    <img class="fade-in" alt="[[alt]]">
+
+    <img alt="[[alt]]">
   </template>
 
   <script>
@@ -48,7 +53,10 @@
           /**
            *  Image source
            * */
-          src: String,
+          src: {
+            type: String,
+            observer: '_srcChanged',
+          },
           /**
            *  Image alt
            * */
@@ -66,46 +74,72 @@
            * */
           fade: {
             type: Boolean,
-            value: false
-          }
+            value: false,
+            reflectToAttribute: true,
+          },
+          /**
+           *  Settled when the image is visible.
+           * */
+          visible: {
+            type: Boolean,
+            value: false,
+            reflectToAttribute: true,
+          },
+          /**
+           *  Settled when the image is loaded.
+           * */
+          loaded: {
+            type: Boolean,
+            value: false,
+            reflectToAttribute: true,
+          },
         };
       }
 
       static get observers() {
         return [
+          '_displayImageWhenNVisible(src, visible, loaded)',
           '_placeholderChanged(placeholder)'
         ]
+      }
+
+      constructor() {
+        super();
+
+        if (window.IntersectionObserver) {
+          this._io = new IntersectionObserver(entries => {
+            for (const entry of entries) {
+              if (entry.isIntersecting) {
+                this.visible = true;
+                this.loaded = false;
+                this._io.unobserve(this);
+              }
+            }
+          });
+        }
       }
 
       connectedCallback() {
         super.connectedCallback();
 
-        const imgEl = Polymer.dom(this.root).querySelector('img');
+        this._imgEl = Polymer.dom(this.root).querySelector('img');
+      }
 
+      _srcChanged(src) {
         if (window.IntersectionObserver) {
-          const io = new IntersectionObserver(entries => {
-            for (const entry of entries) {
-              if (entry.isIntersecting) {
-                if (this.src) {
-                  imgEl.src = this.src;
-                }
-                io.unobserve(this);
-              }
-            }
-          });
-          io.observe(this);
+          this.visible = false;
+          this._io.observe(this);
         } else {
-          imgEl.src = this.src;
+          this.visible = true;
         }
 
-        if ((document.documentMode || /Edge/.test(navigator.userAgent))) {
-          imgEl.src = this.src;
-        }
+        this.loaded = false;
+      }
 
-        if (this.fade) {
-          imgEl.onload = () => {
-            imgEl.style.display = 'block';
-          }
+      _displayImageWhenNVisible(src, visible, loaded) {
+        if (visible === true && loaded === false) {
+          this._imgEl.onload = () => this.loaded = true;
+          this._imgEl.src = src;
         }
       }
 


### PR DESCRIPTION
Hello,

The `iron-list` element seems to have a pool of elements: it reuses the elements used previously (to improve performance)
In this case, the `src` property is set more than once

With the previous code, the `src` value was in a clojure, so we could not update it

With this patch, the `IntersectionObserver` only sets the `visible` flag
Changing the `visible` flag will update the `img` `src` attribute
After loading the image, it will set the `loading` flag that will show the `img` with CSS