### PR TITLE
Add: IntersectionObserver's options support

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -105,6 +105,44 @@
       </template>
     </demo-snippet>
   </div>
+
+  <div class="vertical-section-container centered">
+    <h3><code>lazy-image</code> inside a scrollable element with custom <code>load-margin-bottom</code> demo</h3>
+    <demo-snippet>
+      <template>
+        <div style="height: 20em; overflow: auto;" id="scroll-element">
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis eligendi neque quae ab similique repudiandae accusamus
+            nemo optio consequuntur laudantium. Rem asperiores aperiam et architecto libero unde nobis sit quasi.</p>
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis eligendi neque quae ab similique repudiandae accusamus
+            nemo optio consequuntur laudantium. Rem asperiores aperiam et architecto libero unde nobis sit quasi.</p>
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis eligendi neque quae ab similique repudiandae accusamus
+            nemo optio consequuntur laudantium. Rem asperiores aperiam et architecto libero unde nobis sit quasi.</p>
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis eligendi neque quae ab similique repudiandae accusamus
+            nemo optio consequuntur laudantium. Rem asperiores aperiam et architecto libero unde nobis sit quasi.</p>
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis eligendi neque quae ab similique repudiandae accusamus
+            nemo optio consequuntur laudantium. Rem asperiores aperiam et architecto libero unde nobis sit quasi.</p>
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis eligendi neque quae ab similique repudiandae accusamus
+            nemo optio consequuntur laudantium. Rem asperiores aperiam et architecto libero unde nobis sit quasi.</p>
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis eligendi neque quae ab similique repudiandae accusamus
+            nemo optio consequuntur laudantium. Rem asperiores aperiam et architecto libero unde nobis sit quasi.</p>
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis eligendi neque quae ab similique repudiandae accusamus
+            nemo optio consequuntur laudantium. Rem asperiores aperiam et architecto libero unde nobis sit quasi.</p>
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis eligendi neque quae ab similique repudiandae accusamus
+            nemo optio consequuntur laudantium. Rem asperiores aperiam et architecto libero unde nobis sit quasi.</p>
+          <lazy-image
+            src="a.jpg"
+            scroll-element="div"
+            load-margin-bottom="100px"
+            style="width: 5em; height: 5em;"
+            id="lazy-image-in-a-scroll-element"
+          ></lazy-image>
+        </div>
+        <script>
+          document.querySelector('#lazy-image-in-a-scroll-element').scrollElement = document.querySelector('#scroll-element')
+        </script>
+      </template>
+    </demo-snippet>
+  </div>
 </body>
 
 </html>

--- a/lazy-image.html
+++ b/lazy-image.html
@@ -99,7 +99,7 @@
 
       static get observers() {
         return [
-          '_displayImageWhenNVisible(src, visible, loaded)',
+          '_displayImageWhenVisible(src, visible, loaded)',
         ]
       }
 
@@ -136,7 +136,7 @@
         this.loaded = false;
       }
 
-      _displayImageWhenNVisible(src, visible, loaded) {
+      _displayImageWhenVisible(src, visible, loaded) {
         if (visible === true && loaded === false) {
           this._imgEl.onload = () => this.loaded = true;
           this._imgEl.src = src;

--- a/lazy-image.html
+++ b/lazy-image.html
@@ -119,7 +119,7 @@
               if (entry.isIntersecting) {
                 this.visible = true;
                 this.loaded = false;
-                this._io.unobserve(this);
+                this._unobserve();
               }
             }
           });
@@ -134,10 +134,23 @@
       }
 
 
+      _observe() {
+        if (window.IntersectionObserver) {
+          this._io.observe(this);
+        }
+      }
+
+      _unobserve() {
+        if (window.IntersectionObserver) {
+          this._io.unobserve(this);
+        }
+      }
+
+
       _srcChanged(src) {
         if (window.IntersectionObserver) {
           this.visible = false;
-          this._io.observe(this);
+          this._observe();
         } else {
           this.visible = true;
         }

--- a/lazy-image.html
+++ b/lazy-image.html
@@ -48,6 +48,8 @@
       static get is() {
         return 'lazy-image';
       }
+
+
       static get properties() {
         return {
           /**
@@ -57,10 +59,12 @@
             type: String,
             observer: '_srcChanged',
           },
+
           /**
            *  Image alt
            * */
           alt: String,
+
           /**
            *  Base64 encoded data to be used as a placeholder until the image is loaded into view.
            *  Note: A width and a height must be specified when using the placeholder.
@@ -78,6 +82,7 @@
             value: false,
             reflectToAttribute: true,
           },
+
           /**
            *  Settled when the image is visible.
            * */
@@ -97,11 +102,13 @@
         };
       }
 
+
       static get observers() {
         return [
           '_displayImageWhenVisible(src, visible, loaded)',
         ]
       }
+
 
       constructor() {
         super();
@@ -119,11 +126,13 @@
         }
       }
 
+
       connectedCallback() {
         super.connectedCallback();
 
         this._imgEl = Polymer.dom(this.root).querySelector('img');
       }
+
 
       _srcChanged(src) {
         if (window.IntersectionObserver) {
@@ -136,12 +145,14 @@
         this.loaded = false;
       }
 
+
       _displayImageWhenVisible(src, visible, loaded) {
         if (visible === true && loaded === false) {
           this._imgEl.onload = () => this.loaded = true;
           this._imgEl.src = src;
         }
       }
+
 
       _placeholderChanged(placeholder) {
         if (placeholder) {

--- a/lazy-image.html
+++ b/lazy-image.html
@@ -84,9 +84,45 @@
           },
 
           /**
-           *  Settled when the image is visible.
+           *  root IntersectionObserver's option described here https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#Parameters
            * */
-          visible: {
+          scrollElement: {
+            type: Object,
+          },
+          /**
+           *  rootMargin IntersectionObserver's option described here https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#Parameters
+           * */
+          loadMargin: {
+            type: String,
+            computed: '_computeLoadMargin(loadMarginTop, loadMarginRight, loadMarginBottom, loadMarginLeft)',
+          },
+          loadMarginTop: {
+            type: String,
+            value: '300px',
+          },
+          loadMarginRight: {
+            type: String,
+            value: '300px',
+          },
+          loadMarginBottom: {
+            type: String,
+            value: '300px',
+          },
+          loadMarginLeft: {
+            type: String,
+            value: '300px',
+          },
+          /**
+           *  thresholds IntersectionObserver's option described here https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#Parameters
+           * */
+          thresholds: {
+            type: Array,
+          },
+
+          /**
+           *  Settled when the image is visible or about to be visible.
+           * */
+          visibleOrAboutTo: {
             type: Boolean,
             value: false,
             reflectToAttribute: true,
@@ -105,7 +141,8 @@
 
       static get observers() {
         return [
-          '_displayImageWhenVisible(src, visible, loaded)',
+          '_recreateIntersectionObserverOption(scrollElement, loadMargin, thresholds)',
+          '_displayImageWhenVisibleOrAboutTo(src, visibleOrAboutTo, loaded)',
         ]
       }
 
@@ -113,16 +150,22 @@
       constructor() {
         super();
 
+        this._isObserving = false;
+        this._createIntersectionObserver();
+      }
+
+
+      _createIntersectionObserver(options) {
         if (window.IntersectionObserver) {
           this._io = new IntersectionObserver(entries => {
             for (const entry of entries) {
               if (entry.isIntersecting) {
-                this.visible = true;
+                this.visibleOrAboutTo = true;
                 this.loaded = false;
                 this._unobserve();
               }
             }
-          });
+          }, options);
         }
       }
 
@@ -136,31 +179,62 @@
 
       _observe() {
         if (window.IntersectionObserver) {
+          this._isObserving = true;
           this._io.observe(this);
         }
       }
 
       _unobserve() {
         if (window.IntersectionObserver) {
+          this._isObserving = false;
           this._io.unobserve(this);
+        }
+      }
+
+
+      _computeLoadMargin(loadMarginTop, loadMarginRight, loadMarginBottom, loadMarginLeft) {
+        return [
+          loadMarginTop,
+          loadMarginRight,
+          loadMarginBottom,
+          loadMarginLeft
+        ].join(' ');
+      }
+
+
+      _recreateIntersectionObserverOption(scrollElement, loadMargin, thresholds) {
+        if (window.IntersectionObserver) {
+          this._io.disconnect();
+
+          const options = {
+            rootMargin: loadMargin,
+          };
+          if (scrollElement) options.root = scrollElement;
+          if (thresholds) options.thresholds = thresholds;
+
+          this._createIntersectionObserver(options);
+
+          if (this._isObserving) {
+            this._observe();
+          }
         }
       }
 
 
       _srcChanged(src) {
         if (window.IntersectionObserver) {
-          this.visible = false;
+          this.visibleOrAboutTo = false;
           this._observe();
         } else {
-          this.visible = true;
+          this.visibleOrAboutTo = true;
         }
 
         this.loaded = false;
       }
 
 
-      _displayImageWhenVisible(src, visible, loaded) {
-        if (visible === true && loaded === false) {
+      _displayImageWhenVisibleOrAboutTo(src, visibleOrAboutTo, loaded) {
+        if (visibleOrAboutTo === true && loaded === false) {
           this._imgEl.onload = () => this.loaded = true;
           this._imgEl.src = src;
         }

--- a/lazy-image.html
+++ b/lazy-image.html
@@ -147,6 +147,9 @@
         if (placeholder) {
           this.style.backgroundImage = `url(${placeholder})`;
         }
+        else {
+          this.style.backgroundImage = null;
+        }
       }
     }
 


### PR DESCRIPTION
This PR allow to load image just before the element is visible in the viewport by setting a margin where the loading is triggered

This margin can be customized with the `load-magin-*` attribute

It's needed to set the `scroll-element` attribute with the element who have the scrollbar if this is not the default scroll behavior (by setting `overflow` CSS propery) ; else the margin will not be taken in account